### PR TITLE
Allow for trailing slash in mv-storage

### DIFF
--- a/src/mavo-firebase.js
+++ b/src/mavo-firebase.js
@@ -269,7 +269,7 @@
     },
 
     static: {
-      test: url => /^(firebase|https:\/\/.*\.firebaseio\.com)$/.test(url)
+      test: url => /^(firebase|https:\/\/.*\.firebaseio\.com\/?)$/.test(url)
     }
   }))
 })()


### PR DESCRIPTION
Just went through some lengthy debugging and the culprit was a trailing slash. Hopefully this should fix it, though not sure if there's a different part of the code that may choke on this.